### PR TITLE
Set better defaults for HA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve defautls to make app more reliable.
+
 ## [1.0.0] - 2023-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve defautls to make app more reliable.
+- Improve defaults to make app more reliable.
 
 ## [1.0.0] - 2023-06-13
 

--- a/helm/linkerd-viz/values.yaml
+++ b/helm/linkerd-viz/values.yaml
@@ -101,12 +101,12 @@ metricsAPI:
       # -- Maximum amount of CPU units that the metrics-api container can use
       limit:
       # -- Amount of CPU units that the metrics-api container requests
-      request:
+      request: 100m
     memory:
       # -- Maximum amount of memory that metrics-api container can use
-      limit:
+      limit: 250Mi
       # -- Amount of memory that the metrics-api container requests
-      request:
+      request: 50Mi
     ephemeral-storage:
       # -- Maximum amount of ephemeral storage that the metrics-api container can use
       limit: ""
@@ -197,12 +197,12 @@ tap:
       # -- Maximum amount of CPU units that the tap container can use
       limit:
       # -- Amount of CPU units that the tap container requests
-      request:
+      request: 100m
     memory:
       # -- Maximum amount of memory that tap container can use
-      limit:
+      limit: 250Mi
       # -- Amount of memory that the tap container requests
-      request:
+      request: 50Mi
     ephemeral-storage:
       # -- Maximum amount of ephemeral storage that the tap container can use
       limit: ""
@@ -264,12 +264,12 @@ tapInjector:
       # -- Maximum amount of CPU units that the tapInjector container can use
       limit:
       # -- Amount of CPU units that the tapInjector container requests
-      request:
+      request: 100m
     memory:
       # -- Maximum amount of memory that tapInjector container can use
-      limit:
+      limit: 250Mi
       # -- Amount of memory that the tapInjector container requests
-      request:
+      request: 50Mi
     ephemeral-storage:
       # -- Maximum amount of ephemeral storage that the tapInjector container can use
       limit: ""
@@ -358,12 +358,12 @@ dashboard:
       # -- Maximum amount of CPU units that the web container can use
       limit:
       # -- Amount of CPU units that the web container requests
-      request:
+      request: 100m
     memory:
       # -- Maximum amount of memory that web container can use
-      limit:
+      limit: 250Mi
       # -- Amount of memory that the web container requests
-      request:
+      request: 50Mi
     ephemeral-storage:
       # -- Maximum amount of ephemeral storage that the web container can use
       limit: ""
@@ -525,12 +525,12 @@ prometheus:
       # -- Maximum amount of CPU units that the prometheus container can use
       limit:
       # -- Amount of CPU units that the prometheus container requests
-      request:
+      request: 300m
     memory:
       # -- Maximum amount of memory that prometheus container can use
-      limit:
+      limit: 6144Mi
       # -- Amount of memory that the prometheus container requests
-      request:
+      request: 300Mi
     ephemeral-storage:
       # -- Maximum amount of ephemeral storage that the prometheus container can use
       limit: ""

--- a/helm/linkerd-viz/values.yaml
+++ b/helm/linkerd-viz/values.yaml
@@ -137,7 +137,7 @@ metricsAPI:
 # tap configuration
 tap:
     # -- Number of tap component replicas
-  replicas: 1
+  replicas: 3
   # -- log level of the tap component
   # @default -- defaultLogLevel
   logLevel: ""
@@ -228,7 +228,7 @@ tap:
 # tapInjector configuration
 tapInjector:
   # -- Number of replicas of tapInjector
-  replicas: 1
+  replicas: 2
   # -- log level of the tapInjector
   # @default -- defaultLogLevel
   logLevel: ""

--- a/helm/linkerd-viz/values.yaml
+++ b/helm/linkerd-viz/values.yaml
@@ -53,7 +53,7 @@ tolerations: &default_tolerations
 # -- Enables Pod Anti Affinity logic to balance the placement of replicas
 # across hosts and zones for High Availability.
 # Enable this only when you have multiple replicas of components.
-enablePodAntiAffinity: false
+enablePodAntiAffinity: true
 
 # -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)

--- a/helm/linkerd-viz/values.yaml
+++ b/helm/linkerd-viz/values.yaml
@@ -249,10 +249,12 @@ tapInjector:
     pullPolicy: ""
 
   namespaceSelector:
-    # matchExpressions:
-    # - key: runlevel
-    #   operator: NotIn
-    #   values: ["0","1"]
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+      - giantswarm
   objectSelector:
     # matchLabels:
     #   foo: bar


### PR DESCRIPTION
This PR:

- enable enablePodAntiAffinity
- set resources for metrics-api, tap, dashboard and prometheus
- increase replicas
- ignore kube-system, cert-manager and giantswarm namespaces on webhook


Towards https://github.com/giantswarm/roadmap/issues/2703 and https://github.com/giantswarm/roadmap/issues/2320

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
