### PR TITLE
Add VPA for viz components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add VPA for tap, tap-injector and metrics-api.
+
 ## [1.4.1] - 2023-12-13
 
 ### Changed

--- a/helm/linkerd-viz/templates/vpa.yaml
+++ b/helm/linkerd-viz/templates/vpa.yaml
@@ -1,0 +1,93 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: tap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: tap
+      controlledValues: RequestsAndLimits
+      mode: Auto
+      {{- with .Values.vpa.tap.minAllowed }}
+      minAllowed:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.vpa.tap.maxAllowed }}
+      maxAllowed:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  tap
+  updatePolicy:
+    updateMode: Auto
+---
+
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: tap-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: tap-injector
+      controlledValues: RequestsAndLimits
+      mode: Auto
+      {{- with .Values.vpa.tapInjector.minAllowed }}
+      minAllowed:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.vpa.tapInjector.maxAllowed }}
+      maxAllowed:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  tap-injector
+  updatePolicy:
+    updateMode: Auto
+---
+
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: metrics-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: metrics-api
+      controlledValues: RequestsAndLimits
+      mode: Auto
+      {{- with .Values.vpa.metricsApi.minAllowed }}
+      minAllowed:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.vpa.metricsApi.maxAllowed }}
+      maxAllowed:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  metrics-api
+  updatePolicy:
+    updateMode: Auto
+{{ end }}

--- a/helm/linkerd-viz/values.schema.json
+++ b/helm/linkerd-viz/values.schema.json
@@ -645,6 +645,48 @@
         },
         "tolerations": {
             "type": ["null", "array"]
+
+        },
+        "vpa": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "metricsApi": {
+                    "type": "object",
+                    "properties": {
+                        "maxAllowed": {
+                            "type": "object"
+                        },
+                        "minAllowed": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "tap": {
+                    "type": "object",
+                    "properties": {
+                        "maxAllowed": {
+                            "type": "object"
+                        },
+                        "minAllowed": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "tapInjector": {
+                    "type": "object",
+                    "properties": {
+                        "maxAllowed": {
+                            "type": "object"
+                        },
+                        "minAllowed": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/helm/linkerd-viz/values.yaml
+++ b/helm/linkerd-viz/values.yaml
@@ -567,3 +567,21 @@ prometheus:
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
   tolerations: *default_tolerations
+
+vpa:
+  enabled: true
+  tap:
+    minAllowed:
+      Cpu: 100m
+      Memory: 50Mi
+    maxAllowed: {}
+  tapInjector:
+    minAllowed:
+      Cpu: 100m
+      Memory: 50Mi
+    maxAllowed: {}
+  metricsApi:
+    minAllowed:
+      Cpu: 100m
+      Memory: 50Mi
+    maxAllowed: {}

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: add nodetaint remover container...
-      sha: 05a70b5ffc1de5df36af2f4d447bad30c096dca6
+      commitTitle: '[GS] add VPA for linkerd-viz...'
+      sha: 01055dd14c7a644c8ef82442f8143acf17bff90c
       tags:
-      - stable-2.10.1-3185-g05a70b5ff
+      - stable-2.10.1-3187-g01055dd14
     path: linkerd
   path: vendor
 - contents:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:

- Add VPA for tap, tap-injector and metrics-api.

Pulled from github.com/giantswarm/linkerd2-upstream with vendir

Towards https://github.com/giantswarm/giantswarm/issues/29468 https://github.com/giantswarm/roadmap/issues/3114


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
